### PR TITLE
GUI rework to fix GUI items misplacements

### DIFF
--- a/addon/globalPlugins/instantTranslate/interface.py
+++ b/addon/globalPlugins/instantTranslate/interface.py
@@ -10,6 +10,7 @@ import os.path
 import sys
 import wx
 import gui
+import gui.guiHelper
 from .langslist import langslist
 from . import langslist as lngModule
 import globalVars
@@ -28,47 +29,40 @@ class InstantTranslateSettingsPanel(gui.SettingsPanel):
 		super(InstantTranslateSettingsPanel, self).__init__(parent)
 
 	def makeSettings(self, sizer):
+		helper = gui.guiHelper.BoxSizerHelper(self, sizer=sizer)
+		
 		# Translators: Help message for a dialog.
 		helpLabel = wx.StaticText(self, label=_("Select translation source and target language:"))
-		helpLabel.Wrap(self.GetSize()[0])
 		sizer.Add(helpLabel)
-		fromSizer = wx.BoxSizer(wx.HORIZONTAL)
+		
 		# Translators: A setting in addon settings dialog.
-		fromLabel = wx.StaticText(self, label=_("Source language:"))
-		fromSizer.Add(fromLabel)
+		fromLabelText = _("Source language:")
 		# list of choices, in alphabetical order but with auto in first position
 		temp = self.prepareChoices()
 		# zh-TW is not present in sources, on site
 		temp1 = deepcopy(temp)
 		temp1.remove(lngModule.g("zh-TW"))
-		self._fromChoice = wx.Choice(self, choices=temp1)
-		fromSizer.Add(self._fromChoice)
-		intoSizer = wx.BoxSizer(wx.HORIZONTAL)
+		self._fromChoice = helper.addLabeledControl(fromLabelText, wx.Choice, choices=temp1)
+		
 		# Translators: A setting in addon settings dialog.
-		intoLabel = wx.StaticText(self, label=_("Target language:"))
-		intoSizer.Add(intoLabel)
+		intoLabelText = _("Target language:")
 		# auto has no sense in target
 		temp.remove(lngModule.g("auto"))
-		self._intoChoice = wx.Choice(self, choices=temp)
-		intoSizer.Add(self._intoChoice)
-		sizer.Add(fromSizer)
-		sizer.Add(intoSizer)
+		self._intoChoice = helper.addLabeledControl(intoLabelText, wx.Choice, choices=temp)
+		
 		# Translators: A setting in addon settings dialog.
-		self.copyTranslationChk = wx.CheckBox(self, label=_("Copy translation result to clipboard"))
+		self.copyTranslationChk = helper.addItem(wx.CheckBox(self, label=_("Copy translation result to clipboard")))
 		self.copyTranslationChk.SetValue(config.conf['instanttranslate']['copytranslatedtext'])
-		sizer.Add(self.copyTranslationChk)
-		self.swapSizer = wx.BoxSizer(wx.HORIZONTAL)
+		
 		# Translators: A setting in addon settings dialog, shown if source language is on auto.
-		swapLabel = wx.StaticText(self, label=_("Language for swapping:"))
-		self.swapSizer.Add(swapLabel)
-		self._swapChoice = wx.Choice(self, choices=temp)
-		self._fromChoice.Bind(wx.EVT_CHOICE, lambda event, sizer=sizer: self.onFromSelect(event, sizer))
-		self.swapSizer.Add(self._swapChoice)
-		sizer.Add(self.swapSizer)
+		swapLabelText = _("Language for swapping:")
+		self._swapChoice = helper.addLabeledControl(swapLabelText, wx.Choice, choices=temp)
+		self._fromChoice.Bind(wx.EVT_CHOICE, self.onFromSelect)
+		
 		# Translators: A setting in addon settings dialog, shown if source language is on auto.
-		self.autoSwapChk = wx.CheckBox(self, label=_("Activate the auto-swap if recognized source is equal to the target (experimental)"))
+		self.autoSwapChk = helper.addItem(wx.CheckBox(self, label=_("Activate the auto-swap if recognized source is equal to the target (experimental)")))
 		self.autoSwapChk.SetValue(config.conf['instanttranslate']['autoswap'])
-		sizer.Add(self.autoSwapChk)
+		
 		iLang_from = self._fromChoice.FindString(self.getDictKey(config.conf['instanttranslate']['from']))
 		iLang_to = self._intoChoice.FindString(self.getDictKey(config.conf['instanttranslate']['into']))
 		iLang_swap = self._swapChoice.FindString(self.getDictKey(config.conf['instanttranslate']['swap']))
@@ -76,8 +70,8 @@ class InstantTranslateSettingsPanel(gui.SettingsPanel):
 		self._intoChoice.Select(iLang_to)
 		self._swapChoice.Select(iLang_swap)
 		if iLang_from != 0:
-			sizer.Hide(self.swapSizer)
-			sizer.Hide(self.autoSwapChk)
+		 	self._swapChoice.Disable()
+		 	self.autoSwapChk.Disable()
 
 	def postInit(self):
 		self._fromChoice.SetFocus()
@@ -96,13 +90,13 @@ class InstantTranslateSettingsPanel(gui.SettingsPanel):
 		choices.extend(keys)
 		return choices
 
-	def onFromSelect(self, event, sizer):
+	def onFromSelect(self, event):
 		if event.GetString() == lngModule.g("auto"):
-			sizer.Show(self.swapSizer)
-			sizer.Show(self.autoSwapChk)
+			self._swapChoice.Enable()
+			self.autoSwapChk.Enable()
 		else:
-			sizer.Hide(self.swapSizer)
-			sizer.Hide(self.autoSwapChk)
+			self._swapChoice.Disable()
+			self.autoSwapChk.Disable()
 
 	def onSave(self):
 		# Update Configuration

--- a/addon/globalPlugins/instantTranslate/interface.py
+++ b/addon/globalPlugins/instantTranslate/interface.py
@@ -50,10 +50,6 @@ class InstantTranslateSettingsPanel(gui.SettingsPanel):
 		temp.remove(lngModule.g("auto"))
 		self._intoChoice = helper.addLabeledControl(intoLabelText, wx.Choice, choices=temp)
 		
-		# Translators: A setting in addon settings dialog.
-		self.copyTranslationChk = helper.addItem(wx.CheckBox(self, label=_("Copy translation result to clipboard")))
-		self.copyTranslationChk.SetValue(config.conf['instanttranslate']['copytranslatedtext'])
-		
 		# Translators: A setting in addon settings dialog, shown if source language is on auto.
 		swapLabelText = _("Language for swapping:")
 		self._swapChoice = helper.addLabeledControl(swapLabelText, wx.Choice, choices=temp)
@@ -63,6 +59,10 @@ class InstantTranslateSettingsPanel(gui.SettingsPanel):
 		self.autoSwapChk = helper.addItem(wx.CheckBox(self, label=_("Activate the auto-swap if recognized source is equal to the target (experimental)")))
 		self.autoSwapChk.SetValue(config.conf['instanttranslate']['autoswap'])
 		
+		# Translators: A setting in addon settings dialog.
+		self.copyTranslationChk = helper.addItem(wx.CheckBox(self, label=_("Copy translation result to clipboard")))
+		self.copyTranslationChk.SetValue(config.conf['instanttranslate']['copytranslatedtext'])
+				
 		iLang_from = self._fromChoice.FindString(self.getDictKey(config.conf['instanttranslate']['from']))
 		iLang_to = self._intoChoice.FindString(self.getDictKey(config.conf['instanttranslate']['into']))
 		iLang_swap = self._swapChoice.FindString(self.getDictKey(config.conf['instanttranslate']['swap']))


### PR DESCRIPTION
### Issue

In the setting panel, just play with first combobox: successively select a real language, e.g. English, and then "auto".
When English is selected, the "swap" options are hidden since not relevant.
When "auto" is selected again, the swap options appear one on the other at the top of the settings panel.
It seems that calling the Show method makes the item appear again in the sizer but it does not re-compute its position according to the items that were already positioned in the sizer before.

### How this PR fixes the issue

* I have used Enable/Disable wx methods rather than Hide/Show. Thus the swap options are not totally hidden anymore; they are just greyed out and the focus cannot jump to them. That is the common strategy to disable some GUI items in NVDA's core setting panels.
* I have used NVDA helper function to simplify the GUI creation. 
* While at it, I have changed the order of the items in the panel. It seemed to me more logical to put the two swap options just after the "from" and "into" comboboxes to which they are related. The "copy last translation to clipboard" is then positioned below as the last option of the panel. This reordering has been done in a separate commit, so if you do not like it, I may revert it independently.

### Tests
Tested the GUI with:
* NVDA 2021.1beta2
* NVDA 2020.4
* NVDA 2019.2.1

### Note

I have opened this PR against stable branch since this is the one that seems more up-to-date and alive. I may rebase on another branch if needed.
