### PR TITLE
Fixed destination language initialization to default system language when there is no config yet.

### DIFF
--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -51,7 +51,7 @@ else:
 
 confspec = {
 "from": "string(default=auto)",
-"into": "string(default={lo_lang})",
+"into": "string(default={lo_lang})".format(lo_lang=lo_lang),
 "swap": "string(default=en)",
 "copytranslatedtext": "boolean(default=true)",
 "autoswap": "boolean(default=true)",


### PR DESCRIPTION
Hi Beqa

The default config visible in the code indicates that when there is no config yet for InstantTranslate in the nvda.ini file, the default system locale should be used. However this does not work.

### Steps to reproduce

1. Take a fresh new NVDA and install InstantTranslate
  Or delete/rename your nvda.ini file, disable auto-saving when exiting and restart NVDA.
2. Assuming NVDA+shift+T has been mapped as the InstantTranslate layer command gesture, press NVDA+shift+T then A to announce current configuration.
3. Select an English text and make it translated by the add-on (NVDA+shift+T then T)

### Actual result

* At step 2, NVDA announces:
  'Translate: from auto to {lo_lang}'.
* At step 3, the text is announced in English
### Expected result

* At step 2 NVDA announces:
  'Translate: from auto to fr'
  (fr being my system language)
* At step 3, the text is announced in French

### How this PR fixes the issue

The default config string for destination language has been formatted correctly with the missing required information.
