### PR TITLE
Added help messages for the function that translates the last spoken text

### DIFF
--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -155,7 +155,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.bindGestures(self.__ITGestures)
 		self.toggling = True
 		tones.beep(100, 10)
-	script_ITLayer.__doc__=_("Instant Translate layer commands. t translates selected text, shift+t translates clipboard text, a announces current swap configuration, s swaps source and target languages, c copies last result to clipboard, i identify the language of selected text.")
+	script_ITLayer.__doc__=_("Instant Translate layer commands. t translates selected text, shift+t translates clipboard text, a announces current swap configuration, s swaps source and target languages, c copies last result to clipboard, i identify the language of selected text, l translates last spoken text.")
 
 	def terminate(self):
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(InstantTranslateSettingsPanel)
@@ -324,7 +324,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	script_translateLastSpokenText.__doc__ = _("It translates the last spoken text")
 
 	def script_displayHelp(self, gesture):
-		ui.message(_("t translates selected text, shift+t translates clipboard text, a announces current swap configuration, s swaps source and target languages, c copies last result to clipboard, i identify the language of selected text, o open translation settings dialog, h displays this message."))
+		ui.message(_("t translates selected text, shift+t translates clipboard text, a announces current swap configuration, s swaps source and target languages, c copies last result to clipboard, i identify the language of selected text, l translates last spoken text, o open translation settings dialog, h displays this message."))
 
 	def script_showSettings(self, gesture):
 		wx.CallAfter(gui.mainFrame._popupSettingsDialog, gui.settingsDialogs.NVDASettingsDialog, InstantTranslateSettingsPanel)

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ All following commands must be pressed after modifier key "NVDA+Shift+t":
 * A: announce current configuration,
 * C: copy last result to clipboard,
 * I: identify the language of selected text,
+* L: translate the last spoken text,
 * O: open translation settings dialog
 * H: announces all available commands to user.
 


### PR DESCRIPTION
In this PR I propose to make the following changes:

* added one line to ReadMe, which describes the function of translating the last spoken text;
* updated the help message of the add-on;
* supplemented the description of the main keyboard command.

These changes were discussed in the comments to PR #1 .

Thank you
