### PR TITLE
Various documentation updates

### DIFF
--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -155,7 +155,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.bindGestures(self.__ITGestures)
 		self.toggling = True
 		tones.beep(100, 10)
-	script_ITLayer.__doc__=_("Instant Translate layer commands. t translates selected text, shift+t translates clipboard text, a announces current swap configuration, s swaps source and target languages, c copies last result to clipboard, i identify the language of selected text, l translates last spoken text.")
+	script_ITLayer.__doc__=_("Instant Translate layer commands. t translates selected text, shift+t translates clipboard text, a announces current swap configuration, s swaps source and target languages, c copies last result to clipboard, i identify the language of selected text, l translates last spoken text, o opens translation setting dialog.")
 
 	def terminate(self):
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(InstantTranslateSettingsPanel)
@@ -325,9 +325,13 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def script_displayHelp(self, gesture):
 		ui.message(_("t translates selected text, shift+t translates clipboard text, a announces current swap configuration, s swaps source and target languages, c copies last result to clipboard, i identify the language of selected text, l translates last spoken text, o open translation settings dialog, h displays this message."))
+	# Translators: Presented in input help mode.
+	script_displayHelp.__doc__ = _("Announces all available layered commands")
 
 	def script_showSettings(self, gesture):
 		wx.CallAfter(gui.mainFrame._popupSettingsDialog, gui.settingsDialogs.NVDASettingsDialog, InstantTranslateSettingsPanel)
+	# Translators: Presented in input help mode.
+	script_showSettings.__doc__ = _("Opens Instant Translate settings dialog.")
 
 	__ITGestures={
 		"kb:t":"translateSelection",

--- a/buildVars.py
+++ b/buildVars.py
@@ -15,7 +15,7 @@ addon_info = {
 	"addon_summary" : _("Instant Translate"),
 	# Add-on description
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
-	"addon_description" : _("This addon translates selected or clipboard text using the Yandex Translate service and presents it."),
+	"addon_description" : _("This addon translates selected or clipboard text using the Google Translate service and presents it."),
 	# version
 	"addon_version" : "4.4.2",
 	# Author(s)

--- a/readme.md
+++ b/readme.md
@@ -24,15 +24,16 @@ Now, the auto-swap checkbox: it appears if and only if you set the auto option i
 
 A simple example: take again in mind the situation  imagined previously; if you translate a text in a language different from English, there is no problem, you get the correct translation in English. But if you need to translate a text from English, normally you get a translation into English identical to original text, and this is a bit useless. Thanks to auto-swap function, however, assuming that you want to know how your text sounds into Italian, the addon commutes automatically the target language to Italian, so it returns a valid translation.
 
-Anyway, this is a temporary configuration; if this option has no effect (it's experimental), try to commute manually to a stable configuration, using the gesture for swapping described below. It's experimental because in some situations (with short texts, tipically), Google does not recognize the real source language correctly, and you have to swap languages manually via script, so to force the source language to be the previous target language (English in our example).
+Anyway, this is a temporary configuration; if this option has no effect (it's experimental), try to commute manually to a stable configuration, using the gesture for swapping described below. It's experimental because in some situations (with short texts, typically), Google does not recognize the real source language correctly, and you have to swap languages manually via script, so to force the source language to be the previous target language (English in our example).
 
 At least, in the speech settings parameters dialog (NVDA Menu >> Preferences >> Speech), you may want to check the "Automatic language switching (when supported)" option. This way, if you are using a multi-lingual synthesizer, the translation will be announced using the target language voice of the synthesizer.
 
 ## Using ##
-You can use this add-on in two ways:
+You can use this add-on in three ways:
 
-1. Select some text using selection commands (shift with arrow keys, for example) and press associated key to translate. translation result willbe read with synthesizer which you are using.
+1. Select some text using selection commands (shift with arrow keys, for example) and press associated key to translate. translation result will be read with synthesizer which you are using.
 2. You can also translate text from the Clipboard.
+3. Press the dedicated shortcut key to translate the last spoken text.
 
 ## Shortcuts ##
 All following commands must be pressed after modifier key "NVDA+Shift+t":
@@ -45,7 +46,7 @@ All following commands must be pressed after modifier key "NVDA+Shift+t":
 * I: identify the language of selected text,
 * L: translate the last spoken text,
 * O: open translation settings dialog
-* H: announces all available commands to user.
+* H: announces all available layered commands.
 
 ## Changes for 4.4.2 ##
 * Restore language detection and auto-swapping (Thanks to Cyrille for fix)


### PR DESCRIPTION
Hi Beqa

Here are some various doc little fixes:
* Add-on description in the buildVars.py / manifest: Yandex -> Google
* Added docstring to the displayHelp and showOptions scripts. This also allows to have them assignable in the input gesture dialog.
* Added the missing 'o' layered command in the description of the main entry point script for layered commands.
* README: fixed spelling issues and added the use of translating last spoken text (taken from #6  by @cary-rowen)
