### PR TITLE
Update minimum version in compatibility information to 2019.3

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -25,7 +25,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
 	# Minimum NVDA version supported
-	"addon_minimumNVDAVersion" : "2018.3",
+	"addon_minimumNVDAVersion" : "2019.3",
 	# Last NVDA version supported/tested
 	"addon_lastTestedNVDAVersion" : "2022.1"
 }


### PR DESCRIPTION
### Link to issue
Fixes #9

### Issue description
The add-on was announcing itself as compatible with NVDA 2018.3 and beyond. However, the code was actually incompatible with NVDA below 2019.3. For reference, NVDA 2019.3 is the first version of NVDA based on Python 3; previous versions are based on Python 2.

The following problem are present on NVDA 2019.2.1 (list not exhaustive):
* the code contains f-strings, whereas this syntax is only supported by Python 3.
* the code uses `speechViewer.SPEECH_ITEM_SEPARATOR` that only appeared in NVDA 2019.3.

### Issue resolution
As discussed in #9, update compatibility to 2019.3.1 and beyond.

### Additional comments

@beqabeqa473, maybe you have bigger projects for this add-ons. But since #9 is opened for 10 months now and since it is a really minor fix, it would be worth merging it now. Thanks.

