### PR TITLE
Fix Python 3.11 syntax

### DIFF
--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -271,7 +271,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		ui.message(_("Language is..."))
 		myTranslator.start()
 		i=0
-		while  myTranslator.isAlive():
+		while  myTranslator.is_alive():
 			sleep(0.1)
 			i+=1
 			if i == 10:


### PR DESCRIPTION
The add-on is working in almost all situations on latest alpha.

Only the script to identify the language causes an error. Indeed `threading.Thread.isAlive` does not exist anymore; `threading.Thread.is_alive` should be used instead.

Note that `threading.Thread.is_alive` (with underscore) was already used in `translateAndCache` and is compatible with Python 3.7.

