### PR TITLE
Do not cache failed translations

### DIFF
--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -184,7 +184,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			langSwap = self.lang_swap
 		else:
 			langSwap = None
-		result = self.translateAndCache(text, langFrom, langTo, langSwap)
+		try:
+			result = self.translateAndCache(text, langFrom, langTo, langSwap)
+		except RuntimeError:
+			return
 		self.lastTranslation = result.translation
 		msgTranslation = {'text': result.translation, 'lang': result.lang_to}
 		queueHandler.queueFunction(queueHandler.eventQueue, messageWithLangDetection, msgTranslation)
@@ -216,6 +219,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				beep(500, 100)
 				i = 0
 		myTranslator.join()
+		if myTranslator.error:
+			queueHandler.queueFunction(queueHandler.eventQueue, ui.message, _("Translation failed"))
+			raise RuntimeError('Translation failure')
 		return myTranslator
 
 	def copyResult(self, translation, ignoreSetting=False):

--- a/addon/globalPlugins/instantTranslate/translator.py
+++ b/addon/globalPlugins/instantTranslate/translator.py
@@ -13,7 +13,6 @@ from time import sleep
 from random import randint
 from logHandler import log
 import ui
-import queueHandler
 
 import json
 import urllib.request as urllibRequest
@@ -75,6 +74,7 @@ class Translator(threading.Thread):
 			if not self.firstChunk:
 				sleep(randint(1, 10))
 			url = urlTemplate.format(lang_from=self.lang_from, lang_to=self.lang_to, text=urllibRequest.quote(chunk.encode('utf-8')))
+			self.error = False
 			try:
 				response = json.load(self.opener.open(url))
 				self.lang_detected = response['src']
@@ -89,6 +89,6 @@ class Translator(threading.Thread):
 				# We have probably been blocked, so stop trying to translate.
 #				log.exception("Instant translate: Can not translate text '%s'" %chunk)
 #				raise e
-				queueHandler.queueFunction(queueHandler.eventQueue, ui.message, _("Translation failed"))
+				self.error = True
 				return
 			self.translation += "".join(sentence["trans"] for sentence in response["sentences"])


### PR DESCRIPTION
### Steps to reproduce
* start NVDA
* select a text
* Disconnect from the internet, e.g. disable WiFi
* Try to translate the selection; logically, translation failure is reported
* Re-enable internet connection
* Try to translate the same selection

### Previous result
No translation
### Result with this PR
The text is now translated.
As a side effect of the code rework, the string "Translation failure" is now correctly translated in NVDA's GUI language, what was not the case before.
