### PR TITLE
Announce full language names when reporting the configuration

### DIFF
--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -260,7 +260,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# Translators: message presented to announce that the source and target languages have been swapped.
 		ui.message(_("Languages swapped"))
 		# Translators: message presented to announce the current source and target languages.
-		ui.message(_("Translate: from {lang1} to {lang2}").format(lang1=self.lang_from, lang2=self.lang_to))
+		ui.message(_("Translate: from {lang1} to {lang2}").format(lang1=g(self.lang_from, short=True), lang2=g(self.lang_to, short=True)))
 		try:
 			# NVDA 2024.1+
 			shouldTranslate = speech.getState().speechMode != speech.SpeechMode.onDemand
@@ -277,7 +277,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	)
 	def script_announceLanguages(self, gesture):
 		# Translators: message presented to announce the current source and target languages.
-		ui.message(_("Translate: from {lang1} to {lang2}").format(lang1=self.lang_from, lang2=self.lang_to))
+		ui.message(_("Translate: from {lang1} to {lang2}").format(lang1=g(self.lang_from, short=True), lang2=g(self.lang_to, short=True)))
 
 	@scriptHandler.script(
 	)

--- a/addon/globalPlugins/instantTranslate/langslist.py
+++ b/addon/globalPlugins/instantTranslate/langslist.py
@@ -10,8 +10,14 @@ from languageHandler import getLanguageDescription
 import addonHandler
 addonHandler.initTranslation()
 
-def g(code):
-	"""Return an NVDA language description for code, if one is available. Otherwise, return the one from needed_codes. If that fails, return the code."""
+def g(code, short=False):
+	"""Return an NVDA language description for code, if one is available. Otherwise, return the one from needed_codes. If that fails, return the code.
+	If short is True, returns a more compact description for the "auto" special code.
+	"""
+	if short and code == "auto":
+		# Translators: A short description for "Automatically detect language" language choice, reported when
+		# the user requests or swaps the current configuration.
+		return _("Automatic")
 	res = getLanguageDescription(code)
 	if res is not None: return res
 	if code in needed_codes:


### PR DESCRIPTION
### Issue
When using `NVDA+shift+t` then A or `NVDA+shift+t` then S, the language codes are reported; having the full language names reported as for `NVDA+shift+t` then I would be more user friendly.

### Solutions
Reports the full language name. For "auto" option, report a shorter name than the GUI option "Automatically detect language".
