### PR TITLE
Update the language list with 24 languages added in May 2022

### DIFF
--- a/addon/globalPlugins/instantTranslate/langslist.py
+++ b/addon/globalPlugins/instantTranslate/langslist.py
@@ -28,9 +28,23 @@ needed_codes = {
 	# Translators: An option to automatically detect source language for translation.
 	"auto":_("Automatically detect language"),
 	# Translators: The name of a language supported by this add-on.
+	"ak": _("Twi (Akan)"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
+	"ay": _("Aymara"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
+	"bho": _("Bhojpuri"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
+	"bm":_("Bambara"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
 	"ceb":_("Cebuano"),
 	# Translators: The name of a language supported by this add-on.
+	"doi": _("Dogri"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
+	"ee": _("Ewe"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
 	"eo":_("Esperanto"),
+	# Translators: The name of a language supported by this add-on.
+	"gom": _("Konkani"),  # Missing, tested on Windows 10 22H2
 	# Translators: The name of a language supported by this add-on.
 	"haw":_("Hawaiian"),
 	# Translators: The name of a language supported by this add-on.
@@ -38,13 +52,27 @@ needed_codes = {
 	# Translators: The name of a language supported by this add-on.
 	"ht":_("Creole Haiti"),
 	# Translators: The name of a language supported by this add-on.
+	"ilo": _("Ilocano"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
 	"jv":_("Javanese"),
+	# Translators: The name of a language supported by this add-on.
+	"kri": _("Krio"),  # Missing, tested on Windows 10 22H2
 	# Translators: The name of a language supported by this add-on.
 	"ku":_("Kurdish"),
 	# Translators: The name of a language supported by this add-on.
 	"la":_("Latin"),
 	# Translators: The name of a language supported by this add-on.
+	"lg":  _("Luganda"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
+	"ln": _("Lingala"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
+	"lus": _("Mizo"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
+	"mai": _("Maithili"),  # Missing, tested on Windows 10 22H2
+	# Translators: The name of a language supported by this add-on.
 	"mg":_("Malagasy"),
+	# Translators: The name of a language supported by this add-on.
+	"mni-Mtei": _("Meiteilon (Manipuri)"),  # Missing, tested on Windows 10 22H2
 	# Translators: The name of a language supported by this add-on.
 	"my":_("Myanmar (Burmese)"),
 	# Translators: The name of a language supported by this add-on.
@@ -70,20 +98,29 @@ needed_codes = {
 langcodes = [
 	"auto",
 	"af",
+	"ak",
 	"am",
 	"ar",
+	"as",
+	"ay",
 	"az",
 	"be",
 	"bg",
+	"bho",
+	"bm",
 	"bn",
 	"bs",
 	"ca",
 	"ceb",
+	"ckb",
 	"co",
 	"cs",
 	"cy",
 	"da",
 	"de",
+	"doi",
+	"dv",
+	"ee",
 	"el",
 	"en",
 	"eo",
@@ -92,11 +129,14 @@ langcodes = [
 	"eu",
 	"fa",
 	"fi",
+	"fil",
 	"fr",
 	"fy",
 	"ga",
 	"gd",
 	"gl",
+	"gn",
+	"gom",
 	"gu",
 	"ha",
 	"haw",
@@ -109,6 +149,7 @@ langcodes = [
 	"hy",
 	"id",
 	"ig",
+	"ilo",
 	"is",
 	"it",
 	"ja",
@@ -118,18 +159,24 @@ langcodes = [
 	"km",
 	"kn",
 	"ko",
+	"kri",
 	"ku",
 	"ky",
 	"la",
 	"lb",
+	"lg",
+	"ln",
 	"lo",
 	"lt",
+	"lus",
 	"lv",
+	"mai",
 	"mg",
 	"mi",
 	"mk",
 	"ml",
 	"mn",
+	"mni-Mtei",
 	"mr",
 	"ms",
 	"mt",
@@ -137,15 +184,19 @@ langcodes = [
 	"ne",
 	"nl",
 	"no",
+	"nso",
 	"ny",
+	"om",
 	"or",
 	"pa",
 	"pl",
 	"ps",
 	"pt",
+	"qu",
 	"ro",
 	"ru",
 	"rw",
+	"sa",
 	"sd",
 	"si",
 	"sk",
@@ -163,9 +214,11 @@ langcodes = [
 	"te",
 	"tg",
 	"th",
+	"ti",
 	"tk",
 	"tl",
 	"tr",
+	"ts",
 	"tt",
 	"ug",
 	"uk",

--- a/addon/globalPlugins/instantTranslate/langslist.py
+++ b/addon/globalPlugins/instantTranslate/langslist.py
@@ -11,18 +11,30 @@ import addonHandler
 addonHandler.initTranslation()
 
 def g(code, short=False):
-	"""Return an NVDA language description for code, if one is available. Otherwise, return the one from needed_codes. If that fails, return the code.
+	"""Return a description for the language code passed as parameter. The first found code is returned.
+	The check order is the following:
+	- the code in the forced codes list, i.e. codes for which NVDA/Windows do not return a satisfactory description
+	- the code is in NVDA/Windows language description
+	- the code in the list of needed codes, i.e. codes not available in some versions of Windows
+	If all these checks fail, return the code.
 	If short is True, returns a more compact description for the "auto" special code.
 	"""
 	if short and code == "auto":
 		# Translators: A short description for "Automatically detect language" language choice, reported when
 		# the user requests or swaps the current configuration.
 		return _("Automatic")
+	if code in forced_codes:
+		return forced_codes[code]
 	res = getLanguageDescription(code)
 	if res is not None: return res
 	if code in needed_codes:
 		return needed_codes[code]
 	return code
+
+forced_codes = {
+	# Translators: The name of a language supported by this add-on.
+	"ckb": _("Kurdish (Sorani)"),
+}
 
 needed_codes = {
 	# Translators: An option to automatically detect source language for translation.

--- a/addon/globalPlugins/instantTranslate/langslist.py
+++ b/addon/globalPlugins/instantTranslate/langslist.py
@@ -7,6 +7,7 @@
 #See the file COPYING for more details.
 
 from languageHandler import getLanguageDescription
+from logHandler import log
 import addonHandler
 addonHandler.initTranslation()
 
@@ -247,4 +248,9 @@ langcodes = [
 
 langslist = {}
 for code in langcodes:
-	langslist[g(code)] = code
+	name = g(code)
+	try:
+		oldName = langslist[name]
+		log.error(f'Unable to add "{name}" (code "{code}"): this language name already exists for code "{oldName}".')
+	except KeyError:
+		langslist[name] = code


### PR DESCRIPTION
24 languages have been [added in May 2022 ](https://blog.google/products/translate/24-new-languages/)in Google translate. This PR adds them to Instant Translate:
* The description of many of these languages are not provided by NVDA/Windows. Thus they have been added in the specific `needed_codes` list.
* When needed, the language names have been taken from https://cloud.google.com/translate/docs/languages?hl=en. This page can be useful for translators too, since there are translated versions of this page.
* Windows, at least Windows 10 22H2 French, returns the same description for "ku" and "ckb", namely "Kurde central", that is "Central Kurdish". Thus I have had to force the description of "ckb" to "Kurdish (Sorani)" as written on [this page](https://cloud.google.com/translate/docs/languages?hl=en).

At last, since [this page](https://cloud.google.com/translate/docs/languages?hl=en) lists both "fil" (Filipino (Tagalog)) and "tl" (Tagalog (Filipino)), I have added "fil" in this same PR. I do not know however if they are just the same language or if Google consider a difference between them. At least with my tests, translating a text to Filipino and performing a language detection on this text returns Tagalog...
Though having both items in the list does not cause any issue, so I keep it anyway.


