### PR TITLE
Add automatic translation feature

### DIFF
--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -271,7 +271,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		ui.message(_("Language is..."))
 		myTranslator.start()
 		i=0
-		while  myTranslator.isAlive():
+		while  myTranslator.is_alive():
 			sleep(0.1)
 			i+=1
 			if i == 10:


### PR DESCRIPTION
## PR Description

**New Feature**  
A new `autoTranslate` layer command is introduced to control whether automatic translation is enabled. This feature automatically translates the last spoken text by NVDA into a specified language, reducing the need for frequent manual translation.

**Default State**  
- The auto-translate feature is disabled by default.

**User Interaction**  
- Users can toggle the auto-translate feature via the `V` command in the layer commands, or bind it to other gestures.

**Method Changes**  
- **`translateAndCache`**:  
  - In auto-translate mode, if translation fails, the original text will be read aloud without a failure message.  
  - In non-auto-translate mode, if translation fails, the message “Translation failed” is announced (default behavior).

## Change Overview  
- **`script_toggleAutoTranslate`**: Toggles the auto-translate mode.  
- **`_localSpeak`**: In auto-translate mode, translates and speaks the translated text; if translation fails, the original text is spoken.  
- **`script_ITLayer`**: Adds the `V` key as a shortcut to toggle the auto-translate mode after `NVDA+Shift+t`.

## Test Cases  
- Verify the behavior when translation succeeds or fails in auto-translate mode.  
- Verify the behavior when switching the auto-translate mode and ensure it functions as expected.
