### PR TITLE
Compatibility with NVDA 2025.1

### DIFF
--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -136,7 +136,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		tones.beep(120, 100)
 
 	@scriptHandler.script(
-		description=_("Instant Translate layer commands. t translates selected text, shift+t translates clipboard text, a announces current swap configuration, s swaps source and target languages, c copies last result to clipboard, i identify the language of selected text, l translates last spoken text, o opens translation setting dialog.")
+		description=_("Instant Translate layer commands. Then press h to list available commands.")
 	)
 	def script_ITLayer(self, gesture):
 		# A run-time binding will occur from which we can perform various layered translation commands.

--- a/buildVars.py
+++ b/buildVars.py
@@ -35,7 +35,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2019.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2024.4.0",
+	"addon_lastTestedNVDAVersion": "2025.1.2",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
Hi @beqabeqa473 

Here is a PR to bump compatibility with NVDA 2025.1 and fix another issue.

### Issue

* NVDA 2025.1 is out for some time, but the add-on has not be updated to be shown as compatible.
* Also, the script description for `NVDA+shift+T`, the layered commands entry point, is outdated (incomplete) after automatic translation capability has been introduced.

### Solution
1. Changed the compatibility value. There does not seem to be other incompatibility introduced with NVDA 2025.1
2. For `NVDA+shift+T`, listing all the available layered commands was becoming a bit long. Thus I now only mention the command "h" to list all the other commands. This way, if new commands are added in the future, this description will not have to be changed again.

### Test
1. I have tested Instant translate with forced compatibility for some time now, and no issue encountered.
2. Checked Input gestures dialog and input help
