### PR TITLE
Fix compatibility with 2026.1

### DIFF
--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -11,7 +11,7 @@ from functools import wraps, lru_cache
 from .interface import InstantTranslateSettingsPanel
 from .langslist import g
 from .speechOnDemand import getSpeechOnDemandParameter, executeWithSpeakOnDemand
-from locale import getdefaultlocale
+from locale import getlocale
 from time import sleep
 from tones import beep
 from .translator import Translator
@@ -50,18 +50,18 @@ addonName = _curAddon.name.lower()
 _addonSummary = _curAddon.manifest['summary']
 addonHandler.initTranslation()
 
-lo_lang = getdefaultlocale()
-s = lo_lang[0]
-if s == "zh_HK":
-	lo_lang = "zh-TW"
-elif s.startswith("zh"):
-	lo_lang = s.replace('_', '-')
-else:
-	lo_lang = s[0:s.find("_")]
+def getLocaleLanguage():
+	lang, _unused = getlocale()
+	if lang == "zh_HK":
+		return "zh-TW"
+	elif lang.startswith("zh"):
+		return lang.replace('_', '-')
+	else:
+		return lang.split("_")[0]
 
 confspec = {
 "from": "string(default=auto)",
-"into": f"string(default={lo_lang})",
+"into": f"string(default={getLocaleLanguage()})",
 "swap": "string(default=en)",
 "copytranslatedtext": "boolean(default=true)",
 "autoswap": "boolean(default=true)",

--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -370,7 +370,13 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		description=_("Opens Instant Translate settings dialog."),
 	)
 	def script_showSettings(self, gesture):
-		wx.CallAfter(gui.mainFrame._popupSettingsDialog, gui.settingsDialogs.NVDASettingsDialog, InstantTranslateSettingsPanel)
+		try:
+			# NVDA version >= 2023.2
+			popupSettingsDialog = gui.mainFrame.popupSettingsDialog
+		except:
+			# NVDA version < 2023.2
+			popupSettingsDialog = gui.mainFrame._popupSettingsDialog
+		wx.CallAfter(popupSettingsDialog, gui.settingsDialogs.NVDASettingsDialog, InstantTranslateSettingsPanel)
 
 	@scriptHandler.script(
 		# Translators: Presented in input help mode.

--- a/addon/globalPlugins/instantTranslate/__init__.py
+++ b/addon/globalPlugins/instantTranslate/__init__.py
@@ -36,9 +36,14 @@ except:
 	from speech import LangChangeCommand
 import braille
 import wx
-import speech
 import speechViewer
-from versionInfo import version_year
+try:
+	# For NVDA 2021.1 and above
+	from speech import speech
+except ImportError:
+	# For NVDA 2020.4 and below
+	import speech
+
 
 _curAddon = addonHandler.getCodeAddon()
 addonName = _curAddon.name.lower()
@@ -53,8 +58,6 @@ elif s.startswith("zh"):
 	lo_lang = s.replace('_', '-')
 else:
 	lo_lang = s[0:s.find("_")]
-
-speechModule = speech.speech if version_year>=2021 else speech
 
 confspec = {
 "from": "string(default=auto)",
@@ -112,8 +115,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.lastTranslation = None
 		InstantTranslateSettingsPanel.addonConf = self.addonConf
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.append(InstantTranslateSettingsPanel)
-		self._speak = speechModule.speak
-		speechModule.speak = self._localSpeak
+		self._speak = speech.speak
+		speech.speak = self._localSpeak
 		self.lastSpokenText = ''
 		self.settings = {"lang_from": "from", "lang_to": "into", "lang_swap": "swap", "copyTranslation": "copytranslatedtext", "autoSwap": "autoswap", "isAutoSwapped": "isautoswapped", "replaceUnderscores": "replaceUnderscores", "useMirror": "useMirror"}
 		[setattr(self.__class__, propertyMethod, property(lambda self, propertyName=propertyName: self.addonConf[propertyName], lambda self, value, propertyName=propertyName: self.addonConf.__setitem__(propertyName, value))) for propertyMethod, propertyName in self.settings.items()]
@@ -150,7 +153,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def terminate(self):
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(InstantTranslateSettingsPanel)
-		speechModule.speak = self._speak
+		speech.speak = self._speak
 
 	@scriptHandler.script(
 		# Translators: message presented in input help mode, when user presses the shortcut keys for this addon.

--- a/addon/globalPlugins/instantTranslate/donate_dialog.py
+++ b/addon/globalPlugins/instantTranslate/donate_dialog.py
@@ -5,18 +5,26 @@
 
 import addonHandler
 import gui
+try:
+    # NVDA version >= 2025.1
+    from gui.message import MessageDialog, DialogType
+    DIALOG_TYPE_WARNING = DialogType.WARNING
+except ImportError:
+    # NVDA version < 2025.1
+    from gui.nvdaControls import MessageDialog
+    DIALOG_TYPE_WARNING = MessageDialog.DIALOG_TYPE_WARNING
 import webbrowser
 import wx
 
 addonHandler.initTranslation()
 
 
-class DonationDialog(gui.nvdaControls.MessageDialog):
+class DonationDialog(MessageDialog):
     YOOMONEY_URL = "https://yoomoney.ru/to/4100117727255296"
     PAYPAL_URL = "https://paypal.me/gozaltech"
 
     def __init__(self, parent, title, message):
-        super().__init__(parent, title, message, dialogType=gui.nvdaControls.MessageDialog.DIALOG_TYPE_WARNING)
+        super().__init__(parent, title, message, dialogType=DIALOG_TYPE_WARNING)
 
     def _addButtons(self, buttonHelper):
         paypalBtn = buttonHelper.addButton(self, label=_("Donate via Paypal"), name="PAYPAL_URL")


### PR DESCRIPTION
### Issue

When trying to override compatibility with NVDA 2026.1beta1, an error occurs at startup and the add-on cannot load.
This is due to the fact that`version_year` has been moved in 2026.1.

Once this first issue is fixed, various deprecation warning can occur:

1. Python Deprecation warning:
```
DEBUGWARNING - Python warning (22:07:38.937) - MainThread (8924):
C:\Users\cyril\AppData\Roaming\nvda\addons\instantTranslate\globalPlugins\instantTranslate\__init__.py:53: ```
DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
  lo_lang = getdefaultlocale()
```

2. Older NVDA deprecation warning introduced in NVDA 2025.1:
```
DEBUGWARNING - Python warning (15:02:46.788) - MainThread (13456):
gui\nvdaControls.pyc:317: DeprecationWarning: gui.nvdaControls.MessageDialog is deprecated. Use gui.messageDialog.MessageDialog instead.
```

3. Older NVDA deprecation warning introduced in NVDA 2023.2:
```
WARNING - gui.MainFrame._popupSettingsDialog (15:02:33.001) - MainThread (13456):
_popupSettingsDialog is deprecated, use popupSettingsDialog instead.
Stack trace:
  File "nvda.pyw", line 309, in <module>
  File "core.pyc", line 1060, in main
  File "wx\core.pyc", line 2254, in MainLoop
  File "wx\core.pyc", line 3425, in <lambda>
  File "gui\__init__.pyc", line 272, in _popupSettingsDialog
```

### Solution
* Rather than checking NVDA version, directly try to import `speech.speech` and else only import `speech`.
* Regarding the Python deprecation: use `getlocale()` as recommended.
* Regarding NVDA deprecation, use recommended replacements.
### Tests
* Tested translation, automatic translation and translation of last spoken text.
* Tested the GUI dialog and checked that no warning is logged anymore.

